### PR TITLE
read customized values if they exists to make hook works.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: wekan-ondra
-version: "0.10.1"
+version: "0.10.2"
 summary: The open-source Trello-like kanban
 description: |
    Wekan is an open-source and collaborative kanban board application.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,14 +7,14 @@ description: |
    Whether you’re maintaining a personal todo list, planning your holidays with some friends, or working in a team on your next revolutionary idea, Kanban boards are an unbeatable tool to keep your things organized. They give you a visual overview of the current state of your project, and make you productive by allowing you to focus on the few items that matter the most.
    depending on your environment, you might need to alter some configuration settings
    use: $ snap set wekan <key>="<key value>"
-    eg $ snap set wekan PORT='8080'
+    eg $ snap set wekan port='8080'
    supported keys:
-     - MONGO_PORT: mongodb binding port, default value is '2017'
-     - MONGO_BIND_IP: mondodb binding IP address, default value is '"127.0.0.1'
-     - PORT: port wekan is exposed on, default value is'8080'
-     - ROOT_URL: wekan root url where wekan can be accessed, default value is 'http://127.0.0.1'
-     - MAIL_URL: wekan's binding to mail server, there is no default value, example value 'smtp://user:pass@mailserver.examples.com:25/'
-     - MAIL_FROM: wekan's admin email address, no default value, example value 'wekan-admin@example.com'
+     - mongodb-port: mongodb binding port, default value is '2017'
+     - mongodb-bind-ip: mondodb binding IP address, default value is '"127.0.0.1'
+     - port: port wekan is exposed on, default value is'8080'
+     - root-url: wekan root url where wekan can be accessed, default value is 'http://127.0.0.1'
+     - mail-url: wekan's binding to mail server, there is no default value, example value 'smtp://user:pass@mailserver.examples.com:25/'
+     - mail-from: wekan's admin email address, no default value, example value 'wekan-admin@example.com'
 
 confinement: strict
 grade: stable

--- a/src/wekan-read-settings
+++ b/src/wekan-read-settings
@@ -2,7 +2,6 @@
 
 # read wekan config
 source $SNAP/bin/config
-source $SNAP_COMMON/wekan_settings.sh
 
 # TODO: uncomment following, once snapctl can be called from outside the hooks
 # for key in ${keys[@]}
@@ -31,8 +30,5 @@ do
       echo "using default value: $key='${!default_value}'"
       export $key=${!default_value}
       # echo "export $key='${!def_value}'" >> $SETTINGS_FILE
-  else
-      echo "using existing value: $key='${!key}'"
-      export $key=${!key}
   fi
 done

--- a/src/wekan-read-settings
+++ b/src/wekan-read-settings
@@ -2,6 +2,7 @@
 
 # read wekan config
 source $SNAP/bin/config
+source $SNAP_COMMON/wekan_settings.sh
 
 # TODO: uncomment following, once snapctl can be called from outside the hooks
 # for key in ${keys[@]}
@@ -31,6 +32,7 @@ do
       export $key=${!default_value}
       # echo "export $key='${!def_value}'" >> $SETTINGS_FILE
   else
-      echo "$key='${!key}'"
+      echo "using existing value: $key='${!key}'"
+      export $key=${!key}
   fi
 done


### PR DESCRIPTION
Currently, it doesn't read settings from $SNAP_COMMON/wekan_settings.sh
which results in regarding customized settings doesn't take effect.
To verify it
sudo snap set wekan-ondra port=9876
sudo snap disable wekan-ondra
sudo snap enable wekan-ondra

Then navigate to localhost:9876 in your browser to check if you can open wekan website from you local.
